### PR TITLE
Potential fix for code scanning alert no. 6: User-controlled data in numeric cast

### DIFF
--- a/spigotv-api/src/main/java/org/bukkit/command/defaults/PlaySoundCommand.java
+++ b/spigotv-api/src/main/java/org/bukkit/command/defaults/PlaySoundCommand.java
@@ -49,6 +49,10 @@ public class PlaySoundCommand extends VanillaCommand {
             minimumVolume = getDouble(sender, args[7], 0.0D, 1.0D);
         case 7:
             pitch = getDouble(sender, args[6], 0.0D, 2.0D);
+            if (pitch < 0.0D || pitch > 2.0D) {
+                sender.sendMessage(ChatColor.RED + "Invalid pitch value. It must be between 0.0 and 2.0.");
+                return false;
+            }
         case 6:
             volume = getDouble(sender, args[5], 0.0D, Float.MAX_VALUE);
         case 5:


### PR DESCRIPTION
Potential fix for [https://github.com/VisionMCNetwork/SpigotV/security/code-scanning/6](https://github.com/VisionMCNetwork/SpigotV/security/code-scanning/6)

To fix the problem, we need to validate the `pitch` value before casting it to a `float`. This can be done by ensuring the value is within the valid range for a `float` type. If the value is outside this range, we should handle it appropriately, such as by setting it to a default value or rejecting the input.

- Add a validation check for the `pitch` value before casting it to a `float`.
- Ensure the `pitch` value is within the range of `0.0D` to `2.0D` as specified in the `getDouble` method call.
- If the value is outside this range, set it to a default value or handle the error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
